### PR TITLE
Move must to devDepedencies to avoid multiple copies of must

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,13 +36,10 @@
     "mocha": "^2.2.5",
     "must": "^0.13.0-beta2",
     "pre-commit": "^1.0.10",
-    "sinon": "^1.15.4"
+    "sinon": "^1.15.4",
+    "must": "^0.13.1"
   },
   "dependencies": {
     "oolong": "^1.12.0"
-  },
-  "peerDependencies": {
-    "must": "^0.13.0-beta2",
-    "sinon": "^1.15.3"
   }
 }


### PR DESCRIPTION
`must` is only used in the unit tests, so there's no need to list it as a `peerDependency`.  I moved it into `devDependencies` so it won't install by default during an `npm install` and thus will avoid the potential of having multiple copies of `must` installed.
